### PR TITLE
CH edits 6/29

### DIFF
--- a/clahe_test.py
+++ b/clahe_test.py
@@ -1,5 +1,10 @@
 from clahelib import clahe
 from PIL import Image
 
-im = Image.open("images/insight_gray8.tif")
-clahe(im, 63, 256, 3.0)
+im = Image.open("images/snow_gray8_small.png")
+
+import cProfile, pstats
+cProfile.run("clahe(im, 63, 256, 3.0)", "{}.profile".format(__file__))
+s = pstats.Stats("{}.profile".format(__file__))
+s.strip_dirs()
+s.sort_stats("time").print_stats(10)

--- a/clahelib.py
+++ b/clahelib.py
@@ -14,6 +14,7 @@ def clahe(image, blockRadius, bins, slope):
 
     y = box_y
     while y < boxYMax:
+        print(y, "of", boxYMax)
         yMin = max(0, y - blockRadius)
         yMax = min(box_height, y + blockRadius + 1)
         h = yMax - yMin
@@ -26,14 +27,14 @@ def clahe(image, blockRadius, bins, slope):
         while yi < yMax:
             xi  = xMin0
             while xi < xMax0:
-                val = roundPositive(pix[xi, yi] / 255 * bins)
+                val = round(pix[xi, yi] / 255 * bins)
                 hist[val] = hist[val] + 1
                 xi = xi + 1
             yi = yi + 1
         
         x = box_x
         while x < boxXMax:
-            v = roundPositive(pix[x, y] / 255 * bins)
+            v = round(pix[x, y] / 255 * bins)
             xMin = max(0, x - blockRadius)
             xMax = x + blockRadius + 1
             w = min(box_width, xMax) - xMin
@@ -45,7 +46,7 @@ def clahe(image, blockRadius, bins, slope):
                 xMin1 = xMin - 1
                 yi = yMin
                 while yi < yMax:
-                    val = roundPositive(pix[xMin1, yi] / 255 * bins)
+                    val = round(pix[xMin1, yi] / 255 * bins)
                     hist[val] = hist[val] - 1
                     yi = yi + 1
             
@@ -53,7 +54,7 @@ def clahe(image, blockRadius, bins, slope):
                 xMax1 = xMax - 1
                 yi = yMin
                 while yi < yMax:
-                    val = roundPositive(pix[xMax1, yi] / 255 * bins)
+                    val = round(pix[xMax1, yi] / 255 * bins)
                     hist[val] = hist[val] + 1
                     yi = yi + 1
             
@@ -88,11 +89,23 @@ def clahe(image, blockRadius, bins, slope):
                     break
 
             hMin = bins
+            '''
             i = 0
             while i < hMin:
                 if clippedHist[i] != 0:
                     hMin = i
                 i = i + 1
+            '''
+            # CH using list in instead
+            if 0 not in clippedHist[0:hMin]: # slice
+                hMin = 1
+
+            # CH: using numpy instead
+            import numpy as np
+            clippedHist_a = np.array(clippedHist)
+            ss = clippedHist_a[0:hMin] # subset
+            if 0 not in ss:
+                hMin = 1
 
             cdf = 0
             i = hMin
@@ -107,14 +120,13 @@ def clahe(image, blockRadius, bins, slope):
                 i = i + 1
             
             cdfMin = clippedHist[hMin]
-            col = roundPositive((cdf - cdfMin) / (cdfMax - cdfMin) * 255) 
+            col = round((cdf - cdfMin) / (cdfMax - cdfMin) * 255) # use build-in round()!
             
             dest_pix[x, y] = col
             x = x + 1
         
         y = y + 1
 
+    print()
     dest_image.save("images/output.png")
 
-def roundPositive(num):
-    return int(num + 0.5)


### PR DESCRIPTION
After a look at your code, I have some suggestions that might help to speed it up but using "better" python idioms:
- instead of you many while loops that do something to <from> to <to>, use list slicing
- to simple test if something is or is not in a list use   x in <list>  or x not in <list>
- lists are inherently much slower than arrays. They cam be grown and can hold a mixture of types but have a large overhead b/c of that. numpy arrays are much better optimized for speed (wrap around C)
- Try to use hole arrays as variables rather than operating on a pixel level. For example: rather than than doing 
round((cdf - cdfMin) / (cdfMax - cdfMin) * 255)
 for each pixel, have cdf be an array  and use numpy.round() on the result
- Not sure if this would work for this algorithm but try operate on arrays wherever you can (memory is cheap and fast these days) b/c numpy can do an operation on 100,000 cells much faster than you iterating over each cell in a while loop.
- Note: numpy is a bit obtuse to get into b/c it has a very powerful, but complicated infrastructure build in. However, stackoverflow usually helps :)